### PR TITLE
Fix crash when attempting to call plugin function

### DIFF
--- a/core/include/plugin.h
+++ b/core/include/plugin.h
@@ -68,9 +68,13 @@ public:
      *         other I/O errors occur.
      */
     Plugin(const std::string &name, const std::filesystem::path &directory);
-    Plugin(Plugin &&) = default;
+    Plugin(Plugin &&other) noexcept;
     Plugin &
-    operator=(Plugin &&) = default;
+    operator=(Plugin &&other) noexcept;
+
+    Plugin(const Plugin &) = delete;
+    Plugin &
+    operator=(const Plugin &) = delete;
 
     ~Plugin();
 
@@ -131,4 +135,7 @@ private:
 
     bool
     unload_lib();
+
+    friend void
+    swap(Plugin &first, Plugin &second) noexcept;
 };

--- a/core/src/plugin.cpp
+++ b/core/src/plugin.cpp
@@ -53,6 +53,17 @@ Plugin::Function::is_valid() const {
     return *fptr_;
 }
 
+void
+swap(Plugin &first, Plugin &second) noexcept {
+    using std::swap;
+    swap(first.lib_name_, second.lib_name_);
+    swap(first.lib_dir_, second.lib_dir_);
+    swap(first.lib_time_, second.lib_time_);
+    swap(first.tmp_dir_, second.tmp_dir_);
+    swap(first.lib_, second.lib_);
+    swap(first.funcs_, second.funcs_);
+}
+
 Plugin::Plugin(const std::string &name, const std::filesystem::path &directory)
     : lib_name_(name)
     , lib_dir_(directory / shared_lib_name(name))
@@ -70,6 +81,16 @@ Plugin::Plugin(const std::string &name, const std::filesystem::path &directory)
         " into ",
         tmp_dir_.string());
     Debug::log(lib_dir_.string(), " has write time ", Util::put_time_point(lib_time_));
+}
+
+Plugin::Plugin(Plugin &&other) noexcept {
+    swap(*this, other);
+}
+
+Plugin &
+Plugin::operator=(Plugin &&other) noexcept {
+    swap(*this, other);
+    return *this;
 }
 
 Plugin::~Plugin() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,7 +43,7 @@ main(int argc, char **argv) {
     auto &window = GLFW::Window::get(1280, 720, "Roguelike");
 
     std::vector<std::pair<Plugin, Plugin::Function>> plugins;
-    plugins.reserve(argc - 1);
+    plugins.reserve(argc - 2);
     for (int i = 2; i < argc; i++) {
         try {
             auto plugin = Plugin(argv[i], argv[1]);


### PR DESCRIPTION
Plugin object was being moved from then went out of scope. The default move constructor was just copying its members, leaving it with valid data after being moved from. When the destructor was called, the original library object was considered valid so the library was unloaded.